### PR TITLE
Add black point compensation

### DIFF
--- a/shaders/hdr-toys/tone-mapping/bt2390.glsl
+++ b/shaders/hdr-toys/tone-mapping/bt2390.glsl
@@ -23,34 +23,6 @@
 //!BIND HOOKED
 //!DESC tone mapping (bt.2390)
 
-const float DISPGAMMA = 2.4;
-const float L_W = 1.0;
-const float L_B = 0.0;
-
-float bt1886_r(float L, float gamma, float Lw, float Lb) {
-    float a = pow(pow(Lw, 1.0 / gamma) - pow(Lb, 1.0 / gamma), gamma);
-    float b = pow(Lb, 1.0 / gamma) / (pow(Lw, 1.0 / gamma) - pow(Lb, 1.0 / gamma));
-    float V = pow(max(L / a, 0.0), 1.0 / gamma) - b;
-    return V;
-}
-
-float bt1886_f(float V, float gamma, float Lw, float Lb) {
-    float a = pow(pow(Lw, 1.0 / gamma) - pow(Lb, 1.0 / gamma), gamma);
-    float b = pow(Lb, 1.0 / gamma) / (pow(Lw, 1.0 / gamma) - pow(Lb, 1.0 / gamma));
-    float L = a * pow(max(V + b, 0.0), gamma);
-    return L;
-}
-
-float curve_clip(float x) {
-    x = bt1886_r(x, DISPGAMMA, L_W, L_W / CONTRAST_sdr);
-    x = bt1886_f(x, DISPGAMMA, L_W, L_B);
-    return x;
-}
-
-vec3 tone_mapping_rgb(vec3 RGB) {
-    return vec3(curve_clip(RGB.r), curve_clip(RGB.g), curve_clip(RGB.b));
-}
-
 const float pq_m1 = 0.1593017578125;
 const float pq_m2 = 78.84375;
 const float pq_c1 = 0.8359375;
@@ -200,7 +172,6 @@ vec4 hook() {
     color.rgb = RGB_to_ICtCp(color.rgb);
     color.rgb = tone_mapping_ictcp(color.rgb);
     color.rgb = ICtCp_to_RGB(color.rgb);
-    color.rgb = tone_mapping_rgb(color.rgb);
 
     return color;
 }

--- a/shaders/hdr-toys/transfer-function/bt1886.glsl
+++ b/shaders/hdr-toys/transfer-function/bt1886.glsl
@@ -1,10 +1,16 @@
+// https://www.itu.int/rec/R-REC-BT.1886
+
+//!PARAM CONTRAST_sdr
+//!TYPE float
+//!MINIMUM 0
+//!MAXIMUM 1000000
+1000.0
+
 //!HOOK OUTPUT
 //!BIND HOOKED
 //!DESC transfer function (bt.1886)
 
 const float GAMMA = 2.4;
-const float L_W = 1.0;
-const float L_B = 0.0;
 
 // The reference EOTF specified in Rec. ITU-R BT.1886
 // L = a(max[(V+b),0])^g
@@ -15,14 +21,18 @@ float bt1886_r(float L, float gamma, float Lw, float Lb) {
     return V;
 }
 
+vec3 bt1886_r_f3(vec3 L, float gamma, float Lw, float Lb) {
+    return vec3(
+        bt1886_r(L.r, gamma, Lw, Lb),
+        bt1886_r(L.g, gamma, Lw, Lb),
+        bt1886_r(L.b, gamma, Lw, Lb)
+    );
+}
+
 vec4 hook() {
     vec4 color = HOOKED_texOff(0);
 
-    color.rgb = vec3(
-        bt1886_r(color.r, GAMMA, L_W, L_B),
-        bt1886_r(color.g, GAMMA, L_W, L_B),
-        bt1886_r(color.b, GAMMA, L_W, L_B)
-    );
+    color.rgb = bt1886_r_f3(color.rgb, GAMMA, 1.0, 1.0 / CONTRAST_sdr);
 
     return color;
 }

--- a/shaders/hdr-toys/transfer-function/bt1886_inv.glsl
+++ b/shaders/hdr-toys/transfer-function/bt1886_inv.glsl
@@ -1,10 +1,16 @@
+// https://www.itu.int/rec/R-REC-BT.1886
+
+//!PARAM CONTRAST_sdr
+//!TYPE float
+//!MINIMUM 0
+//!MAXIMUM 1000000
+1000.0
+
 //!HOOK OUTPUT
 //!BIND HOOKED
 //!DESC transfer function (bt.1886, inverse)
 
 const float GAMMA = 2.4;
-const float L_W = 1.0;
-const float L_B = 0.0;
 
 // The reference EOTF specified in Rec. ITU-R BT.1886
 // L = a(max[(V+b),0])^g
@@ -15,14 +21,18 @@ float bt1886_f(float V, float gamma, float Lw, float Lb) {
     return L;
 }
 
+vec3 bt1886_f_f3(vec3 V, float gamma, float Lw, float Lb) {
+    return vec3(
+        bt1886_f(V.r, gamma, Lw, Lb),
+        bt1886_f(V.g, gamma, Lw, Lb),
+        bt1886_f(V.b, gamma, Lw, Lb)
+    );
+}
+
 vec4 hook() {
     vec4 color = HOOKED_texOff(0);
 
-    color.rgb = vec3(
-        bt1886_f(color.r, GAMMA, L_W, L_B),
-        bt1886_f(color.g, GAMMA, L_W, L_B),
-        bt1886_f(color.b, GAMMA, L_W, L_B)
-    );
+    color.rgb = bt1886_f_f3(color.rgb, GAMMA, 1.0, 1.0 / CONTRAST_sdr);
 
     return color;
 }

--- a/shaders/hdr-toys/utils/black_point_compensation.glsl
+++ b/shaders/hdr-toys/utils/black_point_compensation.glsl
@@ -1,0 +1,42 @@
+// https://www.color.org/WP40-Black_Point_Compensation_2010-07-27.pdf
+
+//!PARAM CONTRAST_sdr
+//!TYPE float
+//!MINIMUM 0
+//!MAXIMUM 1000000
+1000.0
+
+//!HOOK OUTPUT
+//!BIND HOOKED
+//!DESC black point compensation
+
+vec3 RGB_to_XYZ(vec3 RGB) {
+    mat3 M = mat3(
+        0.6369580483012914, 0.14461690358620832,  0.1688809751641721,
+        0.2627002120112671, 0.6779980715188708,   0.05930171646986196,
+        0.000000000000000,  0.028072693049087428, 1.060985057710791);
+    return RGB * M;
+}
+
+vec3 XYZ_to_RGB(vec3 XYZ) {
+    mat3 M = mat3(
+         1.716651187971268,  -0.355670783776392, -0.253366281373660,
+        -0.666684351832489,   1.616481236634939,  0.0157685458139111,
+         0.017639857445311,  -0.042770613257809,  0.942103121235474);
+    return XYZ * M;
+}
+
+vec3 T(vec3 XYZ, float s, float d) {
+    float r = (1.0 - d) / (1.0 - s);
+    return r * XYZ + (1.0 - r) * RGB_to_XYZ(vec3(1.0));
+}
+
+vec4 hook() {
+    vec4 color = HOOKED_texOff(0);
+
+    color.rgb = RGB_to_XYZ(color.rgb);
+    color.rgb = T(color.rgb, 0.0, 1.0 / CONTRAST_sdr);
+    color.rgb = XYZ_to_RGB(color.rgb);
+
+    return color;
+}


### PR DESCRIPTION
I'm not sure if this is needed/necessary. If the answer is yes, it should be done in tone-mapping, just like what bt.2390 did.

Follow https://www.color.org/WP40-Black_Point_Compensation_2010-07-27.pdf

- bpc is already included in bt2390, so remove bt1886 trick here.
- toe of dynamic make image too dark, remove it.
- L_black of bt1886 and inverse been changed to 1 / 1000.

matrices is for bt2020, add it after tone-mapping. as above bt2390 doesn't need this.

```diff
glsl-shader=~~/shaders/hdr-toys/utils/clip_both.glsl
glsl-shader=~~/shaders/hdr-toys/transfer-function/pq_inv.glsl
glsl-shader=~~/shaders/hdr-toys/tone-mapping/dynamic.glsl
+ glsl-shader=~~/shaders/hdr-toys/utils/black_point_compensation.glsl
glsl-shader=~~/shaders/hdr-toys/gamut-mapping/bottosson.glsl
glsl-shader=~~/shaders/hdr-toys/transfer-function/bt1886.glsl
```

**Note:**

Update README, if this been merged.