### PR TITLE
Auto Exposure

### DIFF
--- a/shaders/hdr-toys/tone-mapping/astra.glsl
+++ b/shaders/hdr-toys/tone-mapping/astra.glsl
@@ -754,7 +754,7 @@ float get_avg_i() {
     if (max_fall > 0.0)
         return pq_eotf_inv(max_fall);
 
-    return pq_eotf_inv(50.0);
+    return pq_eotf_inv(58.535);
 }
 
 float f(float x, float iw, float ib, float ow, float ob) {
@@ -810,9 +810,16 @@ vec3 tone_mapping(vec3 iab) {
     return vec3(i2, ab2);
 }
 
+vec3 auto_exposure(vec3 color) {
+    float avg = pq_eotf(get_avg_i());
+    float ev = min(log2(58.535 / avg), 0.0);
+    return color * exp2(ev);
+}
+
 vec4 hook() {
     vec4 color = HOOKED_tex(HOOKED_pos);
 
+    color.rgb = auto_exposure(color.rgb);
     color.rgb = RGB_to_Jab(color.rgb);
     color.rgb = tone_mapping(color.rgb);
     color.rgb = Jab_to_RGB(color.rgb);

--- a/shaders/hdr-toys/tone-mapping/astra.glsl
+++ b/shaders/hdr-toys/tone-mapping/astra.glsl
@@ -751,10 +751,10 @@ float get_avg_i() {
     if (scene_avg > 0.0)
         return pq_eotf_inv(scene_avg);
 
-    if (max_fall > 0.0)
-        return pq_eotf_inv(max_fall);
+    // if (max_fall > 0.0)
+    //     return pq_eotf_inv(max_fall);
 
-    return pq_eotf_inv(58.535);
+    return 0.0;
 }
 
 float f(float x, float iw, float ib, float ow, float ob) {
@@ -822,7 +822,12 @@ vec3 tone_mapping(vec3 iab) {
 }
 
 vec3 auto_exposure(vec3 color) {
-    float avg = pq_eotf(get_avg_i());
+    float avg_i = get_avg_i();
+
+    if (avg_i <= 0.0)
+        return color;
+
+    float avg = pq_eotf(avg_i);
     float mxx = pq_eotf(get_max_i());
     float ref = reference_white;
 

--- a/shaders/hdr-toys/tone-mapping/astra.glsl
+++ b/shaders/hdr-toys/tone-mapping/astra.glsl
@@ -53,6 +53,12 @@
 //!MAXIMUM 1000.0
 203.0
 
+//!PARAM auto_exposure_anchor
+//!TYPE float
+//!MINIMUM 0.0
+//!MAXIMUM 1.0
+0.8
+
 //!PARAM chroma_correction_scaling
 //!TYPE float
 //!MINIMUM 0.0
@@ -822,6 +828,9 @@ vec3 tone_mapping(vec3 iab) {
 }
 
 vec3 auto_exposure(vec3 color) {
+    if (auto_exposure_anchor <= 0.0)
+        return color;
+
     float avg_i = get_avg_i();
 
     if (avg_i <= 0.0)
@@ -830,9 +839,12 @@ vec3 auto_exposure(vec3 color) {
     float avg = pq_eotf(avg_i);
     float mxx = pq_eotf(get_max_i());
     float ref = reference_white;
+    float ach = pq_eotf(J_to_I(
+        I_to_J(pq_eotf_inv(reference_white)) * auto_exposure_anchor
+    ));
 
     ev = clamp(
-        log2(max(58.535 / avg, 1e-6)),
+        log2(max(ach / avg, 1e-6)),
         log2(max(ref / mxx, 1e-6)),
         0.0
     );


### PR DESCRIPTION
Currently only valid for videos with dynamic metadata.

**Where is 0 EV?**

~~58.535 takes from BT.2446C
RTX HDR uses 50 nit as middle grey
Should I calculate 75% of Jz for reference white?~~

80% of Jz for reference white

**Previews**

|                                          before                                           |                                           after                                           |
| :---------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------: |
| ![image](https://github.com/user-attachments/assets/ea513f91-9cf1-4bcc-85fe-0acfeb0a81ab) | ![image](https://github.com/user-attachments/assets/e6f5ded6-801b-44a8-a575-af6816595a1a) |
