### PR TITLE
Introduce exposure_value parameter in astra.glsl

### DIFF
--- a/shaders/hdr-toys/tone-mapping/astra.glsl
+++ b/shaders/hdr-toys/tone-mapping/astra.glsl
@@ -80,6 +80,12 @@
 //!MAXIMUM 1
 1
 
+//!PARAM exposure_value
+//!TYPE float
+//!MINIMUM -64
+//!MAXIMUM  64
+0.0
+
 //!PARAM shadow_weight
 //!TYPE float
 //!MINIMUM 0.0
@@ -1216,6 +1222,12 @@ void hook() {
         ev = get_ev(avg_i, max_i, min_i);
     } else {
         ev = 0.0;
+    }
+
+    // Optional external override (name and range per utils/exposure.glsl):
+    // replaces the metered value entirely. 0.0 = automatic metering.
+    if (exposure_value != 0.0) {
+        ev = exposure_value;
     }
 
     if (ev != 0.0) {


### PR DESCRIPTION
Adds an optional `exposure_value` parameter that replaces the metered ev
when non-zero. Name and range per `utils/exposure.glsl`, as requested in
#100. `0.0` = default, fully inert.

Lets external controllers (scripts, per-title presets, hotkeys) drive
exposure through astra's native pathway — metadata compensation and the
tone curve stay consistent within the same frame, and negative values
work. With astra in the chain this effectively supersedes loading
`exposure.glsl`, hence the shared name.

12 lines, no behavior change at default.