### PR TITLE
Fix metering map resolution and reduce it by averaging

### DIFF
--- a/shaders/hdr-toys/tone-mapping/astra.glsl
+++ b/shaders/hdr-toys/tone-mapping/astra.glsl
@@ -603,6 +603,8 @@ void hook() {
 //!BIND METERING
 //!BIND METERED
 //!SAVE EMPTY
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!COMPUTE 32 32
 //!DESC metering (max, min)
 

--- a/shaders/hdr-toys/tone-mapping/astra.glsl
+++ b/shaders/hdr-toys/tone-mapping/astra.glsl
@@ -280,6 +280,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 0 >
 //!DESC metering (spatial stabilization, blur, horizonal)
 
@@ -303,6 +305,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 0 >
 //!DESC metering (spatial stabilization, blur, vertical)
 
@@ -322,6 +326,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 1 >
 //!DESC metering (spatial stabilization, blur, horizonal)
 
@@ -341,6 +347,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 1 >
 //!DESC metering (spatial stabilization, blur, vertical)
 
@@ -360,6 +368,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 2 >
 //!DESC metering (spatial stabilization, blur, horizonal)
 
@@ -379,6 +389,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 2 >
 //!DESC metering (spatial stabilization, blur, vertical)
 
@@ -398,6 +410,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 3 >
 //!DESC metering (spatial stabilization, blur, horizonal)
 
@@ -417,6 +431,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 3 >
 //!DESC metering (spatial stabilization, blur, vertical)
 
@@ -436,6 +452,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 4 >
 //!DESC metering (spatial stabilization, blur, horizonal)
 
@@ -455,6 +473,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 4 >
 //!DESC metering (spatial stabilization, blur, vertical)
 
@@ -474,6 +494,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 5 >
 //!DESC metering (spatial stabilization, blur, horizonal)
 
@@ -493,6 +515,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 5 >
 //!DESC metering (spatial stabilization, blur, vertical)
 
@@ -512,6 +536,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 6 >
 //!DESC metering (spatial stabilization, blur, horizonal)
 
@@ -531,6 +557,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 6 >
 //!DESC metering (spatial stabilization, blur, vertical)
 
@@ -550,6 +578,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 7 >
 //!DESC metering (spatial stabilization, blur, horizonal)
 
@@ -569,6 +599,8 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
+//!WIDTH METERING.w
+//!HEIGHT METERING.h
 //!WHEN spatial_stable_iterations 7 >
 //!DESC metering (spatial stabilization, blur, vertical)
 

--- a/shaders/hdr-toys/tone-mapping/astra.glsl
+++ b/shaders/hdr-toys/tone-mapping/astra.glsl
@@ -222,6 +222,50 @@ vec4 hook() {
     return vec4(vec3(intensity), 1.0);
 }
 
+// The metering map used to be reduced to 512x288 in a single step. At 4K that
+// is a factor of 7.5 per axis taken with one bilinear tap, i.e. point sampling
+// with aliasing: which pixels survive depends on the subpixel alignment, so a
+// small moving highlight makes metered_max_i jump while nothing in the scene
+// changes. Halving repeatedly instead averages exactly 2x2 per step, the same
+// way the average chain below already does it. The passes are conditional, so
+// only as many run as the source resolution needs: two at 4K, one at 1080p.
+
+//!HOOK OUTPUT
+//!BIND METERING
+//!SAVE METERING
+//!WIDTH METERING.w 2 /
+//!HEIGHT METERING.h 2 /
+//!WHEN METERING.w 1024 >
+//!DESC metering (spatial stabilization, halve 1)
+vec4 hook() { return METERING_tex(METERING_pos); }
+
+//!HOOK OUTPUT
+//!BIND METERING
+//!SAVE METERING
+//!WIDTH METERING.w 2 /
+//!HEIGHT METERING.h 2 /
+//!WHEN METERING.w 1024 >
+//!DESC metering (spatial stabilization, halve 2)
+vec4 hook() { return METERING_tex(METERING_pos); }
+
+//!HOOK OUTPUT
+//!BIND METERING
+//!SAVE METERING
+//!WIDTH METERING.w 2 /
+//!HEIGHT METERING.h 2 /
+//!WHEN METERING.w 1024 >
+//!DESC metering (spatial stabilization, halve 3)
+vec4 hook() { return METERING_tex(METERING_pos); }
+
+//!HOOK OUTPUT
+//!BIND METERING
+//!SAVE METERING
+//!WIDTH METERING.w 2 /
+//!HEIGHT METERING.h 2 /
+//!WHEN METERING.w 1024 >
+//!DESC metering (spatial stabilization, halve 4)
+vec4 hook() { return METERING_tex(METERING_pos); }
+
 //!HOOK OUTPUT
 //!BIND METERING
 //!SAVE METERING
@@ -637,58 +681,62 @@ vec4 hook() {
 //!HOOK OUTPUT
 //!BIND AVG
 //!SAVE AVG
-//!WIDTH AVG.w 2 /
-//!HEIGHT AVG.h 2 /
-//!DESC metering (avg, 128)
-vec4 hook() { return AVG_tex(AVG_pos); }
-
-//!HOOK OUTPUT
-//!BIND AVG
-//!SAVE AVG
-//!WIDTH AVG.w 2 /
-//!HEIGHT AVG.h 2 /
+//!WIDTH AVG.w 4 /
+//!HEIGHT AVG.h 4 /
 //!DESC metering (avg, 64)
-vec4 hook() { return AVG_tex(AVG_pos); }
+// Four bilinear taps, each averaging 2x2, tiled over the 4x4 source block.
+vec4 hook() {
+    float s = AVG_texOff(vec2(-1.0, -1.0)).x
+            + AVG_texOff(vec2( 1.0, -1.0)).x
+            + AVG_texOff(vec2(-1.0,  1.0)).x
+            + AVG_texOff(vec2( 1.0,  1.0)).x;
+    return vec4(s * 0.25, 0.0, 0.0, 1.0);
+}
 
 //!HOOK OUTPUT
 //!BIND AVG
 //!SAVE AVG
-//!WIDTH AVG.w 2 /
-//!HEIGHT AVG.h 2 /
-//!DESC metering (avg, 32)
-vec4 hook() { return AVG_tex(AVG_pos); }
-
-//!HOOK OUTPUT
-//!BIND AVG
-//!SAVE AVG
-//!WIDTH AVG.w 2 /
-//!HEIGHT AVG.h 2 /
+//!WIDTH AVG.w 4 /
+//!HEIGHT AVG.h 4 /
 //!DESC metering (avg, 16)
-vec4 hook() { return AVG_tex(AVG_pos); }
+// Four bilinear taps, each averaging 2x2, tiled over the 4x4 source block.
+vec4 hook() {
+    float s = AVG_texOff(vec2(-1.0, -1.0)).x
+            + AVG_texOff(vec2( 1.0, -1.0)).x
+            + AVG_texOff(vec2(-1.0,  1.0)).x
+            + AVG_texOff(vec2( 1.0,  1.0)).x;
+    return vec4(s * 0.25, 0.0, 0.0, 1.0);
+}
 
 //!HOOK OUTPUT
 //!BIND AVG
 //!SAVE AVG
-//!WIDTH AVG.w 2 /
-//!HEIGHT AVG.h 2 /
-//!DESC metering (avg, 8)
-vec4 hook() { return AVG_tex(AVG_pos); }
-
-//!HOOK OUTPUT
-//!BIND AVG
-//!SAVE AVG
-//!WIDTH AVG.w 2 /
-//!HEIGHT AVG.h 2 /
+//!WIDTH AVG.w 4 /
+//!HEIGHT AVG.h 4 /
 //!DESC metering (avg, 4)
-vec4 hook() { return AVG_tex(AVG_pos); }
+// Four bilinear taps, each averaging 2x2, tiled over the 4x4 source block.
+vec4 hook() {
+    float s = AVG_texOff(vec2(-1.0, -1.0)).x
+            + AVG_texOff(vec2( 1.0, -1.0)).x
+            + AVG_texOff(vec2(-1.0,  1.0)).x
+            + AVG_texOff(vec2( 1.0,  1.0)).x;
+    return vec4(s * 0.25, 0.0, 0.0, 1.0);
+}
 
 //!HOOK OUTPUT
 //!BIND AVG
 //!SAVE AVG
-//!WIDTH AVG.w 2 /
-//!HEIGHT AVG.h 2 /
-//!DESC metering (avg, 2)
-vec4 hook() { return AVG_tex(AVG_pos); }
+//!WIDTH AVG.w 4 /
+//!HEIGHT AVG.h 4 /
+//!DESC metering (avg, 1)
+// Four bilinear taps, each averaging 2x2, tiled over the 4x4 source block.
+vec4 hook() {
+    float s = AVG_texOff(vec2(-1.0, -1.0)).x
+            + AVG_texOff(vec2( 1.0, -1.0)).x
+            + AVG_texOff(vec2(-1.0,  1.0)).x
+            + AVG_texOff(vec2( 1.0,  1.0)).x;
+    return vec4(s * 0.25, 0.0, 0.0, 1.0);
+}
 
 //!HOOK OUTPUT
 //!BIND AVG


### PR DESCRIPTION

Three related problems in the metering chain, found while profiling the
per-pass GPU timers.

**The blur stages rewrite METERING at full resolution.** All sixteen carry
`//!SAVE METERING` without `//!WIDTH` or `//!HEIGHT`, so the output texture
takes the size of the hooked texture and undoes the reduction two stages
earlier. Two consequences: the stages cost about 470 us each where a
separable 5 tap blur over 512x288 should be single digit, and the kernel
offsets are fixed in texel units, so the blur covers 5.6x less of the image
than intended. `spatial_stable_iterations` barely smooths anything today.

**The max/min reduction dispatches at full resolution.** The stage has
`//!COMPUTE 32 32` and no dimensions, so at 2880x1620 it runs 4.7 million
invocations and 4590 workgroups to reduce 147456 texels. The adjacent init
stage already combines `//!SAVE EMPTY` with explicit dimensions, so the
directives are honored on an output-less stage.

**The metering map is point sampled, not averaged.** It goes from full
resolution to 512x288 in a single step whose body is one bilinear tap. At
2880x1620 that is a factor of 5.6 per axis: which pixels survive depends on
the subpixel alignment, so a small moving highlight makes `metered_max_i`
jump while nothing in the scene changes. Replaced with repeated halving, each
step averaging exactly 2x2, guarded by `//!WHEN` so only as many stages run
as the render resolution needs. The average chain had the opposite problem,
correct but spread over eight render target roundtrips; four bilinear taps
tile a 4x4 block exactly, so it reduces by 4x per pass instead of 2x.

Measured at 2880x1620, same scene:

| stage | before | after |
|---|---|---|
| blur x4 | 1897 us | 141 us |
| max, min | 748 us | 48 us |
| reduction chain | — | +260 us |
| **net** | | **−2196 us** |

Active pass count: 33 at 1080p, 34 at 2880x1620 and at 4K, 35 at 8K, against
35 before.

**Behavior note:** the blur now covers the image region it was designed for,
so it suppresses isolated outliers as intended rather than nearly not at all.
Metered MAX will read lower than before. The default of
`spatial_stable_iterations = 2` was calibrated against a filter that was
close to the identity, so it may be worth revisiting.